### PR TITLE
Change primary dependency for uc_feeds

### DIFF
--- a/uc_feeds.info
+++ b/uc_feeds.info
@@ -1,7 +1,7 @@
 name = Ubercart Feeds
 description = Integrates Ubercart properties with Feeds
 package = Feeds
-dependencies[] = uc_product
+dependencies[] = ubercart
 dependencies[] = feeds
 backdrop = 1.x
 type = module


### PR DESCRIPTION
The primary dependency for uc_feeds was set to "uc_product". Ubercart was changed so that required dependencies were enforced and hidden, product being one of those dependencies. Instead, the dependency for uc_feeds should be "ubercart" since that is the actual dependency. This is all paraphrased from the original BD UC port maintainer.

Otherwise, uc_feeds throws an error during module enable that uc_feeds needs uc_product to be enabled, even though it technically is already enabled.

I missed this in earlier commits because the site I am using this on, already had uc_feeds installed. This dependency issue especially causes problems on new uc_feed installs.

This commit alone warrants an updated release for uc_feeds because it creates major UX problems during the installation process.